### PR TITLE
Make requets.Session injectable

### DIFF
--- a/queuery_client/queuery_client.py
+++ b/queuery_client/queuery_client.py
@@ -1,5 +1,7 @@
 from typing import Optional
 
+from requests import Session
+
 from queuery_client.client import Client
 from queuery_client.exceptions import QueueryError
 from queuery_client.response import Response
@@ -11,11 +13,13 @@ class QueueryClient:
         endpoint: Optional[str] = None,
         timeout: int = 300,
         enable_cast: bool = False,
+        session: Optional[Session] = None,
     ) -> None:
         self._client = Client(
             endpoint=endpoint,
             timeout=timeout,
             enable_cast=enable_cast,
+            session=session,
         )
 
     def run(self, sql: str) -> Response:

--- a/queuery_client/response.py
+++ b/queuery_client/response.py
@@ -4,7 +4,7 @@ import gzip
 from io import StringIO
 from typing import Any, Dict, Iterator, List, Literal, Optional, Union, overload
 
-import requests
+from requests import Session
 
 from queuery_client.cast import cast_row
 
@@ -34,12 +34,13 @@ class Response:
         self,
         response: ResponseBody,
         enable_cast: bool = False,
+        session: Optional[Session] = None,
     ):
         self._response = response
         self._data_file_urls = response.data_file_urls
         self._cursor = 0
         self._parser = csv.reader
-        self._session = requests.Session()
+        self._session = Session()
         self._enable_cast = enable_cast
         self._manifest: Optional[Dict[str, Any]] = None
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,7 +40,7 @@ def test_client() -> None:
         201,
     )
 
-    with mock.patch("requests.post", return_value=response):
+    with mock.patch("requests.Session.post", return_value=response):
         _ = client._client.execute_query("select 1 from target.tabele")
 
 
@@ -59,7 +59,7 @@ def test_client_with_type_cast() -> None:
         201,
     )
 
-    with mock.patch("requests.post", return_value=response):
+    with mock.patch("requests.Session.post", return_value=response):
         queuery_response = client._client.execute_query("select 1 from target.table")
         assert queuery_response._enable_cast
         assert queuery_response._response.manifest_file_url == "https://queuery.example.com/manifest"


### PR DESCRIPTION
Make `requets.Session` injectable to configure remote server connections.
In this PR, the `session` option is added to `QueueryClient.__init__` to support retries, etc. as follows:

```python
from requests import Session
from requests.adapters import HTTPAdapter
from urllib3.util.retry import Retry

from queuery_client import QueueryClient

session = Session()
session.mount(
    "https://",
    HTTPAdapter(
        max_retries=Retry(
            connect=2,
            total=5,
            backoff_factor=1,
            status_forcelist=[500, 502, 503, 504],
        ),
    ),
)

client = QueueryClient(session=session)
```

The given `session` is passed to the `Response` object and is used not only to connect to the Queuery server, but also to access unloaded files. Thus, you can write different configurations for the Queuery server / S3, etc.

```python
session.mount(
    "https://queuery.example.com",
    HTTPAdapter(max_retries=Retry(total=3)),
)
session.mount(
    "https://your-bucket.s3.ap-northeast-1.amazonaws.com",
    HTTPAdapter(max_retries=Retry(connect=3, total=5)),
)
```