### PR TITLE
Add some features  that makes use of manifest files

### DIFF
--- a/queuery_client/client.py
+++ b/queuery_client/client.py
@@ -23,6 +23,7 @@ class Client(object):
         timeout: int = 300,
         enable_cast: bool = False,
         session: Optional[Session] = None,
+        use_manifest: Optional[bool] = None,
     ) -> None:
         endpoint = endpoint or os.getenv("QUEUERY_ENDPOINT")
         if endpoint is None:
@@ -33,6 +34,7 @@ class Client(object):
         self._timeout = timeout
         self._enable_cast = enable_cast
         self._session = session or Session()
+        self._use_manifest = use_manifest
 
     @property
     def _auth(self) -> Optional[Tuple[str, str]]:
@@ -78,6 +80,7 @@ class Client(object):
                 response=body,
                 enable_cast=self._enable_cast,
                 session=self._session,
+                use_manifest=self._use_manifest,
             )
 
     def wait_for(self, qid: int) -> Response:

--- a/queuery_client/queuery_client.py
+++ b/queuery_client/queuery_client.py
@@ -14,12 +14,14 @@ class QueueryClient:
         timeout: int = 300,
         enable_cast: bool = False,
         session: Optional[Session] = None,
+        use_manifest: Optional[bool] = None,
     ) -> None:
         self._client = Client(
             endpoint=endpoint,
             timeout=timeout,
             enable_cast=enable_cast,
             session=session,
+            use_manifest=use_manifest,
         )
 
     def run(self, sql: str) -> Response:

--- a/queuery_client/response.py
+++ b/queuery_client/response.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Iterator, List, Literal, Optional, Union, overload
 from requests import Session
 
 from queuery_client.cast import cast_row
+from queuery_client.util import SizedIterator
 
 try:
     import pandas
@@ -35,21 +36,33 @@ class Response:
         response: ResponseBody,
         enable_cast: bool = False,
         session: Optional[Session] = None,
+        use_manifest: Optional[bool] = None,
     ):
+        if enable_cast and use_manifest is False:
+            raise ValueError("enable_cast is not available when use_manifest is False.")
+
         self._response = response
         self._data_file_urls = response.data_file_urls
         self._parser = csv.reader
         self._session = Session()
         self._enable_cast = enable_cast
+        self._use_manifest = use_manifest or enable_cast
         self._manifest: Optional[Dict[str, Any]] = None
 
     def __iter__(self) -> Iterator[List[Any]]:
-        for url in self._data_file_urls:
-            for row in self._open(url):
-                if self._enable_cast:
-                    yield cast_row(row, self.fetch_manifest())
-                else:
-                    yield row
+        def get_iterator() -> Iterator[List[Any]]:
+            for url in self._data_file_urls:
+                for row in self._open(url):
+                    if self._enable_cast:
+                        yield cast_row(row, self.fetch_manifest())
+                    else:
+                        yield row
+
+        if self._use_manifest:
+            record_count = self.fetch_record_count()
+            return SizedIterator(get_iterator(), record_count)
+
+        return get_iterator()
 
     def _open(self, url: str) -> List[List[str]]:
         data = self._session.get(url).content
@@ -58,14 +71,26 @@ class Response:
         return list(reader)
 
     def fetch_manifest(self, force: bool = False) -> Dict[str, Any]:
+        if not self._use_manifest:
+            raise RuntimeError("Manifest file is not available.")
         if self._manifest is None or force:
             if not self._response.manifest_file_url:
-                raise RuntimeError("Response does not contain manifest_file_url.")
+                raise RuntimeError(
+                    "Manifest is not available because response does not contain manifest_file_url."
+                )
 
             manifest = self._session.get(self._response.manifest_file_url).json()
             assert isinstance(manifest, dict)
             self._manifest = manifest
         return self._manifest
+
+    def fetch_record_count(self) -> int:
+        manifest = self.fetch_manifest()
+        return int(manifest["meta"]["record_count"])
+
+    def fetch_column_names(self) -> List[str]:
+        manifest = self.fetch_manifest()
+        return [x["name"] for x in manifest["schema"]["elements"]]
 
     @overload
     def read(self) -> List[List[Any]]:
@@ -91,6 +116,10 @@ class Response:
                     "pandas is not availabe. Please make sure that "
                     "pandas is successfully installed to use use_pandas option."
                 )
+
+            if self._use_manifest:
+                return pandas.DataFrame(elems, columns=self.fetch_column_names())
+
             return pandas.DataFrame(elems)
 
         return elems

--- a/queuery_client/response.py
+++ b/queuery_client/response.py
@@ -38,7 +38,6 @@ class Response:
     ):
         self._response = response
         self._data_file_urls = response.data_file_urls
-        self._cursor = 0
         self._parser = csv.reader
         self._session = Session()
         self._enable_cast = enable_cast
@@ -56,8 +55,6 @@ class Response:
         data = self._session.get(url).content
         response = gzip.decompress(data).decode()
         reader = csv.reader(StringIO(response), escapechar="\\")
-
-        self._cursor += 1
         return list(reader)
 
     def fetch_manifest(self, force: bool = False) -> Dict[str, Any]:

--- a/queuery_client/util.py
+++ b/queuery_client/util.py
@@ -1,0 +1,26 @@
+from typing import Generic, Iterator, TypeVar
+
+T = TypeVar("T")
+
+
+class SizedIterator(Generic[T]):
+    """
+    A wrapper for an iterator that knows its size.
+
+    Args:
+        iterator: The iterator.
+        size: The size of the iterator.
+    """
+
+    def __init__(self, iterator: Iterator[T], size: int):
+        self.iterator = iterator
+        self.size = size
+
+    def __iter__(self) -> Iterator[T]:
+        return self.iterator
+
+    def __next__(self) -> T:
+        return next(self.iterator)
+
+    def __len__(self) -> int:
+        return self.size

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -44,12 +44,15 @@ def test_response_with_type_cast() -> None:
 
     manifest_response = MockResponse(
         b"""
-        {"schema": {
-            "elements": [
-                {"name": "id", "type": {"base": "integer"}},
-                {"name": "title", "type": {"base": "character varying"}}
-            ]
-        }}
+        {
+            "schema": {
+                "elements": [
+                    {"name": "id", "type": {"base": "integer"}},
+                    {"name": "title", "type": {"base": "character varying"}}
+                ]
+            },
+            "meta": {"record_count": 2}
+        }
         """,
         200,
     )

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -1,3 +1,4 @@
+import dataclasses
 import gzip
 import json
 from typing import Any, Dict
@@ -63,3 +64,41 @@ def test_response_with_type_cast() -> None:
     with mock.patch("requests.Session.get", return_value=data_response):
         data = response.read()
         assert data == [[1, "test_recipe1"], [2, "test_recipe2"]]
+
+
+def test_response_with_map() -> None:
+    @dataclasses.dataclass
+    class Item:
+        id: int
+        title: str
+
+    response_body = ResponseBody(
+        id=1,
+        data_file_urls=["https://queuery.example.com/data"],
+        error=None,
+        status="success",
+        manifest_file_url="https://queuery.example.com/manifest",
+    )
+    response = Response(response_body, enable_cast=True)
+
+    manifest_response = MockResponse(
+        b"""
+        {
+            "schema": {
+                "elements": [
+                    {"name": "id", "type": {"base": "integer"}},
+                    {"name": "title", "type": {"base": "character varying"}}
+                ]
+            },
+            "meta": {"record_count": 2}
+        }
+        """,
+        200,
+    )
+    with mock.patch("requests.Session.get", return_value=manifest_response):
+        response.fetch_manifest()
+
+    data_response = MockResponse(gzip.compress(b'"1","test_recipe1"\n"2","test_recipe2"'), 200)
+    with mock.patch("requests.Session.get", return_value=data_response):
+        data = list(response.map(Item))
+        assert data == [Item(id=1, title="test_recipe1"), Item(id=2, title="test_recipe2")]


### PR DESCRIPTION
This PR add some features  that makes use of manifest files:

## Utilizing manifest files

- Add `use_manifest` option to `QueueryClient`
- If a manifest file is set to available (when `use_manifest=True` or `enable_cast=True`):
  - a manifest file is automatically downloaded before fetching data
  - a `pandas.DataFrame` returned by `read(use_pandas=True)` has column names according to the manifest
  - an iterator returned by `__iter__(...)` can be `Sized` object with the record count

## `map()` method

In addition, `map()` method is added to `Response` and can be used as follows:

```python
@dataclasses.dataclass
class Item:
    id: int
    title: str


client = QueueryClient(enable_cast=True)
response = client.run("select id, title from your_table")

for item in response.map(Item):
    assert isinstance(item, Item)
```